### PR TITLE
Randomize port for each raw test server.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -557,7 +557,6 @@ export class SubscriptionClient {
 
           // Send CONNECTION_INIT message, no need to wait for connection to success (reduce roundtrips)
           this.sendMessage(undefined, MessageTypes.GQL_CONNECTION_INIT, connectionParams);
-          this.flushUnsentMessagesQueue();
         } catch (error) {
           this.sendMessage(undefined, MessageTypes.GQL_CONNECTION_ERROR, error);
           this.flushUnsentMessagesQueue();
@@ -620,6 +619,7 @@ export class SubscriptionClient {
         if (this.connectionCallback) {
           this.connectionCallback();
         }
+        this.flushUnsentMessagesQueue();
         break;
 
       case MessageTypes.GQL_COMPLETE:

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -632,7 +632,7 @@ describe('Client', function () {
       });
     });
 
-    const client = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+    const client = new SubscriptionClient(`ws://localhost:${rawTestPort}/`, {
       reconnect: true,
     });
 
@@ -670,7 +670,7 @@ describe('Client', function () {
       });
     });
 
-    const client = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+    const client = new SubscriptionClient(`ws://localhost:${rawTestPort}/`, {
       reconnect: true,
     });
 
@@ -877,33 +877,6 @@ describe('Client', function () {
 
       setTimeout(() => {
         testPubsub.publish('user', {});
-      }, 100);
-    });
-  });
-
-  it('queues messages while websocket is still connecting', function (done) {
-    const client = new SubscriptionClient(`ws://localhost:${TEST_PORT}/`);
-
-    let sub = client.request({
-        query: `subscription useInfo($id: String) {
-        user(id: $id) {
-          id
-          name
-        }
-      }`,
-        operationName: 'useInfo',
-        variables: {
-          id: 3,
-        },
-      }).subscribe({});
-
-    client.onConnecting(() => {
-      expect((client as any).unsentMessagesQueue.length).to.equals(1);
-      sub.unsubscribe();
-
-      setTimeout(() => {
-        expect((client as any).unsentMessagesQueue.length).to.equals(0);
-        done();
       }, 100);
     });
   });
@@ -1335,6 +1308,8 @@ describe('Client', function () {
   it('should delete operation when receive a GQL_COMPLETE', (done) => {
     const subscriptionsClient = new SubscriptionClient(`ws://localhost:${rawTestPort}/`);
     subscriptionsClient.operations['1'] = {
+      processed: true,
+      started: true,
       options: {
         query: 'invalid',
       },

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -293,7 +293,9 @@ describe('Client', function () {
       connection.on('message', (message: any) => {
         const parsedMessage = JSON.parse(message);
 
-        if (parsedMessage.type === MessageTypes.GQL_START) {
+        if (parsedMessage.type === MessageTypes.GQL_CONNECTION_INIT) {
+          connection.send(JSON.stringify({ type: MessageTypes.GQL_CONNECTION_ACK, payload: {} }));
+        } else if (parsedMessage.type === MessageTypes.GQL_START) {
           subscriptionsCount++;
         }
       });
@@ -924,7 +926,9 @@ describe('Client', function () {
     wsServer.on('connection', (connection: WebSocket) => {
       connection.on('message', (message: any) => {
         const parsedMessage = JSON.parse(message);
-        if (parsedMessage.type === MessageTypes.GQL_START) {
+        if (parsedMessage.type === MessageTypes.GQL_CONNECTION_INIT) {
+          connection.send(JSON.stringify({ type: MessageTypes.GQL_CONNECTION_ACK, payload: {} }));
+        } else if (parsedMessage.type === MessageTypes.GQL_START) {
           connection.send(JSON.stringify({
             type: MessageTypes.GQL_ERROR,
             id: parsedMessage.id,
@@ -1089,7 +1093,9 @@ describe('Client', function () {
       connections += 1;
       connection.on('message', (message: any) => {
         const parsedMessage = JSON.parse(message);
-        if (parsedMessage.type === MessageTypes.GQL_START) {
+        if (parsedMessage.type === MessageTypes.GQL_CONNECTION_INIT) {
+          connection.send(JSON.stringify({ type: MessageTypes.GQL_CONNECTION_ACK, payload: {} }));
+        } else if (parsedMessage.type === MessageTypes.GQL_START) {
           if (connections === 1) {
             client.client.close();
           } else {

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -39,7 +39,6 @@ import { $$asyncIterator } from 'iterall';
 const TEST_PORT = 4953;
 const KEEP_ALIVE_TEST_PORT = TEST_PORT + 1;
 const DELAYED_TEST_PORT = TEST_PORT + 2;
-const RAW_TEST_PORT = TEST_PORT + 4;
 const EVENTS_TEST_PORT = TEST_PORT + 5;
 const ONCONNECT_ERROR_TEST_PORT = TEST_PORT + 6;
 const ERROR_TEST_PORT = TEST_PORT + 7;
@@ -238,14 +237,16 @@ new SubscriptionServer(Object.assign({}, options, {
   },
 }), { server: httpServerWithDelay });
 
-const httpServerRaw = createServer(notFoundRequestListener);
-httpServerRaw.listen(RAW_TEST_PORT);
-
 describe('Client', function () {
 
+  let httpServerRaw: Server;
   let wsServer: WebSocket.Server;
+  let rawTestPort: number;
 
   beforeEach(() => {
+    httpServerRaw = createServer(notFoundRequestListener);
+    httpServerRaw.listen();
+    rawTestPort = httpServerRaw.address().port;
     wsServer = new WebSocket.Server({
       server: httpServerRaw,
     });
@@ -254,6 +255,9 @@ describe('Client', function () {
   afterEach(() => {
     if (wsServer) {
       wsServer.close();
+    }
+    if (httpServerRaw) {
+      httpServerRaw.close();
     }
   });
 
@@ -266,7 +270,7 @@ describe('Client', function () {
       });
     });
 
-    new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`);
+    new SubscriptionClient(`ws://localhost:${rawTestPort}/`);
   });
 
   it('should subscribe once after reconnect', (done) => {
@@ -293,7 +297,7 @@ describe('Client', function () {
       });
     });
 
-    const client = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+    const client = new SubscriptionClient(`ws://localhost:${rawTestPort}/`, {
       reconnect: true,
       reconnectionAttempts: 1,
     });
@@ -317,7 +321,7 @@ describe('Client', function () {
     let initReceived = false;
 
     let sub: any;
-    const client = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`);
+    const client = new SubscriptionClient(`ws://localhost:${rawTestPort}/`);
     wsServer.on('connection', (connection: any) => {
       connection.on('message', (message: any) => {
         const parsedMessage = JSON.parse(message);
@@ -523,7 +527,7 @@ describe('Client', function () {
       });
     });
 
-    const client = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`);
+    const client = new SubscriptionClient(`ws://localhost:${rawTestPort}/`);
 
     client.request(
       {
@@ -558,7 +562,7 @@ describe('Client', function () {
       });
     });
 
-    new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+    new SubscriptionClient(`ws://localhost:${rawTestPort}/`, {
       connectionParams: connectionParams,
     });
   });
@@ -575,7 +579,7 @@ describe('Client', function () {
       });
     });
 
-    new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+    new SubscriptionClient(`ws://localhost:${rawTestPort}/`, {
       connectionParams: new Promise((resolve) => {
         setTimeout(() => {
           resolve(connectionParams);
@@ -596,7 +600,7 @@ describe('Client', function () {
       });
     });
 
-    new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+    new SubscriptionClient(`ws://localhost:${rawTestPort}/`, {
       connectionParams: new Promise((resolve) => {
         setTimeout(() => {
           resolve(connectionParams);
@@ -616,7 +620,7 @@ describe('Client', function () {
       });
     });
 
-    new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+    new SubscriptionClient(`ws://localhost:${rawTestPort}/`, {
       connectionParams: new Promise((_, reject) => {
         setTimeout(() => {
           reject(error);
@@ -687,7 +691,7 @@ describe('Client', function () {
       });
     });
 
-    new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+    new SubscriptionClient(`ws://localhost:${rawTestPort}/`, {
       connectionCallback: (error: any) => {
         expect(error.message).to.equals('test error');
         done();
@@ -714,7 +718,7 @@ describe('Client', function () {
       });
     });
 
-    client = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`);
+    client = new SubscriptionClient(`ws://localhost:${rawTestPort}/`);
   });
 
   it('should handle correctly GQL_CONNECTION_ACK message', (done) => {
@@ -724,7 +728,7 @@ describe('Client', function () {
       });
     });
 
-    new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+    new SubscriptionClient(`ws://localhost:${rawTestPort}/`, {
       connectionCallback: (error: any) => {
         expect(error).to.equals(undefined);
         done();
@@ -860,7 +864,7 @@ describe('Client', function () {
       });
     });
 
-    const client = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`);
+    const client = new SubscriptionClient(`ws://localhost:${rawTestPort}/`);
     client.request({
       query: `
         subscription useInfo{
@@ -878,7 +882,7 @@ describe('Client', function () {
   }
 
   it('should not connect until subscribe is called if lazy mode', (done) => {
-    const client: SubscriptionClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+    const client: SubscriptionClient = new SubscriptionClient(`ws://localhost:${rawTestPort}/`, {
       lazy: true,
     });
     expect(client.client).to.be.null;
@@ -921,7 +925,7 @@ describe('Client', function () {
       foo: 'bar',
     }));
 
-    const client: SubscriptionClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+    const client: SubscriptionClient = new SubscriptionClient(`ws://localhost:${rawTestPort}/`, {
       lazy: true,
       connectionParams,
     });
@@ -994,7 +998,7 @@ describe('Client', function () {
         done();
       }
     });
-    client = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, { reconnect: true });
+    client = new SubscriptionClient(`ws://localhost:${rawTestPort}/`, { reconnect: true });
     originalClient = client.client;
   });
 
@@ -1016,7 +1020,7 @@ describe('Client', function () {
         }
       });
     });
-    client = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, { reconnect: true });
+    client = new SubscriptionClient(`ws://localhost:${rawTestPort}/`, { reconnect: true });
 
     sub = client.request({
       query: `
@@ -1057,7 +1061,7 @@ describe('Client', function () {
       connection.close();
     });
     let errorCount = 0;
-    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${rawTestPort}/`, {
       timeout: 500,
       reconnect: true,
       reconnectionAttempts: 2,
@@ -1076,7 +1080,7 @@ describe('Client', function () {
   });
 
   it('should stop trying to reconnect to the server if it does not receives the ack', function (done) {
-    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${rawTestPort}/`, {
       timeout: 500,
       reconnect: true,
       reconnectionAttempts: 2,
@@ -1099,7 +1103,7 @@ describe('Client', function () {
   });
 
   it('should keep trying to reconnect if receives the ack from the server', function (done) {
-    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${rawTestPort}/`, {
       timeout: 500,
       reconnect: true,
       reconnectionAttempts: 2,
@@ -1170,7 +1174,7 @@ describe('Client', function () {
   });
 
   it('should take care of invalid message received', (done) => {
-    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`);
+    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${rawTestPort}/`);
     const originalOnMessage = subscriptionsClient.client.onmessage;
     const dataToSend = {
       data: JSON.stringify({ type: 'invalid' }),
@@ -1183,7 +1187,7 @@ describe('Client', function () {
   });
 
   it('should throw if received data is not JSON-parseable', (done) => {
-    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`);
+    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${rawTestPort}/`);
     const originalOnMessage = subscriptionsClient.client.onmessage;
     const dataToSend = {
       data: 'invalid',
@@ -1196,7 +1200,7 @@ describe('Client', function () {
   });
 
   it('should delete operation when receive a GQL_COMPLETE', (done) => {
-    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`);
+    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${rawTestPort}/`);
     subscriptionsClient.operations['1'] = {
       options: {
         query: 'invalid',
@@ -1218,7 +1222,7 @@ describe('Client', function () {
   });
 
   it('should force close the connection without tryReconnect', function (done) {
-    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${rawTestPort}/`, {
       reconnect: true,
       reconnectionAttempts: 1,
     });
@@ -1256,7 +1260,7 @@ describe('Client', function () {
   });
 
   it('should close the connection without sent connection terminate and reconnect', function (done) {
-    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${rawTestPort}/`, {
       reconnect: true,
       reconnectionAttempts: 1,
     });
@@ -1294,7 +1298,7 @@ describe('Client', function () {
   });
 
   it('should close the connection after inactivityTimeout and zero active subscriptions', function (done) {
-    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${RAW_TEST_PORT}/`, {
+    const subscriptionsClient = new SubscriptionClient(`ws://localhost:${rawTestPort}/`, {
       inactivityTimeout: 100,
     });
     const sub = subscriptionsClient.request({


### PR DESCRIPTION
This prevents state from leaking between tests when clients attempt to
reconnect to the same port number each time.<!--
  Thanks for filing a pull request!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change

This prevents state from leaking between tests when clients attempt to
reconnect to the same port number each time.This prevents state from leaking between tests when clients attempt to
reconnect to the same port number each time.